### PR TITLE
Verbose draglint in tox.ini

### DIFF
--- a/.github/workflows/tox.ini
+++ b/.github/workflows/tox.ini
@@ -16,7 +16,7 @@ commands = ruff check --select ALL --ignore INP001 -q {posargs}/extensions/eda/p
 
 [testenv:darglint]
 deps = darglint
-commands = darglint -s numpy -z full {posargs}/extensions/eda/plugins
+commands = darglint -v 2 -s numpy -z full {posargs}/extensions/eda/plugins
 
 
 # If you dont have any event_source or event_filter plugins, remove the corresponding testenv


### PR DESCRIPTION
Enable verbose messages of darglint to understand some of its cryptic errors.