### PR TITLE
Adding pylint disable for import-error test

### DIFF
--- a/.github/workflows/tox.ini
+++ b/.github/workflows/tox.ini
@@ -22,8 +22,8 @@ commands = darglint -s numpy -z full {posargs}/extensions/eda/plugins
 # If you dont have any event_source or event_filter plugins, remove the corresponding testenv
 [testenv:pylint-event-source]
 deps = pylint
-commands = pylint {posargs}/extensions/eda/plugins/event_source/*.py --output-format=parseable -sn --disable R0801
+commands = pylint {posargs}/extensions/eda/plugins/event_source/*.py --output-format=parseable -sn --disable R0801,E0401
 
 [testenv:pylint-event-filter]
 deps = pylint
-commands = pylint {posargs}/extensions/eda/plugins/event_filter/*.py --output-format=parseable -sn --disable R0801
+commands = pylint {posargs}/extensions/eda/plugins/event_filter/*.py --output-format=parseable -sn --disable R0801,E0401


### PR DESCRIPTION
Adding the pylint E0401(import-error) test to disabled tests in the `tox.ini` template. 

This must be disabled as partner content may use external Python imports for their EDA plugins, and tests will fail since the `pylint` tox envs do not contain those libraries. 