### PR TITLE
Adding ignores for certain linter tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
 [testenv:ruff]
 deps = ruff
 commands =
-    bash -c 'ruff check --exclude .tox --select ALL --ignore INP001 -q extensions/eda/plugins'
+    bash -c 'ruff check --exclude .tox --select ALL --ignore INP001,FA102,UP001,UP010,I001,FA100 -q extensions/eda/plugins'
 
 [testenv:darglint]
 deps = darglint
@@ -24,4 +24,4 @@ commands =
 [testenv:pylint]
 deps = pylint
 commands = 
-    bash -c 'find ./extensions/eda/plugins -name "*.py" -print0 | xargs -0 pylint --output-format=parseable -sn --disable R0801'
+    bash -c 'find ./extensions/eda/plugins -name "*.py" -print0 | xargs -0 pylint --output-format=parseable -sn --disable R0801,E0401,C0103,R0913'


### PR DESCRIPTION
Adding ignores for certain linter tests inside of the EDA tox test. These ignores are added for the following reasons:

Ruff:
- [FA100](https://docs.astral.sh/ruff/rules/future-rewritable-type-annotation/): Conflicts with ansible-test sanity 
- [FA102](https://docs.astral.sh/ruff/rules/future-required-type-annotation/): Conflicts with ansible-test sanity
- [UP001](https://docs.astral.sh/ruff/rules/useless-metaclass-type/): Internal test conflict between pylint and ruff
- [UP010](https://docs.astral.sh/ruff/rules/unnecessary-future-import/): Conflicts with ansible-test sanity
- [I001](https://docs.astral.sh/ruff/rules/unsorted-imports/): Can conflict with ansible-test sanity

Pylint:
- [E0401](https://pylint.readthedocs.io/en/latest/user_guide/messages/error/import-error.html): Red herring error resulting from how tox builds linter envs 
- [C0103](https://pylint.readthedocs.io/en/stable/user_guide/messages/convention/invalid-name.html): Internal test conflict between pylint and ruff
- [R0913](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/too-many-arguments.html): Unnecessary test