### PR TITLE
Add new ignores to tox template

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
 [testenv:ruff]
 deps = ruff
 commands =
-    bash -c 'ruff check --exclude .tox --select ALL --ignore INP001,FA102,UP001,UP010,I001,FA100 -q extensions/eda/plugins'
+    bash -c 'ruff check --exclude .tox --select ALL --ignore INP001,FA102,UP001,UP010,I001,FA100,PLR0913,E501 -q extensions/eda/plugins'
 
 [testenv:darglint]
 deps = darglint
@@ -24,4 +24,4 @@ commands =
 [testenv:pylint]
 deps = pylint
 commands = 
-    bash -c 'find ./extensions/eda/plugins -name "*.py" -print0 | xargs -0 pylint --output-format=parseable -sn --disable R0801,E0401,C0103,R0913'
+    bash -c 'find ./extensions/eda/plugins -name "*.py" -print0 | xargs -0 pylint --output-format=parseable -sn --disable R0801,E0401,C0103,R0913,R0902,R0903'


### PR DESCRIPTION
Adds additional ignores for EDA tox linters.

These ignores are added for the following reasons:
Ruff:
[PLR0913](https://docs.astral.sh/ruff/rules/too-many-arguments/): Subjective, not needed for certification
[E501](https://docs.astral.sh/ruff/rules/line-too-long/): Conflicts with Pylint test, and subjective, not needed for certification

Pylint:
[R0902](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/too-many-instance-attributes.html): Subjective, not needed for certification
[R0903](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/too-few-public-methods.html): Subjective, not needed for certification